### PR TITLE
add news carousel to homepage

### DIFF
--- a/assets/product.js
+++ b/assets/product.js
@@ -22,11 +22,6 @@ class ProductDetails extends HTMLElement {
       )
   }
 
-  addNote = (payload) => {
-    // this.orderNote
-    console.log(payload, this.orderNote)
-  }
-
   addToCart = async () => {
     const cartItems = await this.getCartItems()
     if (cartItems) {

--- a/sections/news-carousel.liquid
+++ b/sections/news-carousel.liquid
@@ -1,0 +1,167 @@
+{% assign campaign_block = section.blocks | where: 'type', 'campaign' %}
+{% assign new_product_block = section.blocks | where: 'type', 'new-product' %}
+{% assign news_block = section.blocks | where: 'type', 'news' %}
+
+{% style %}
+  .card {
+    padding: 15px;
+    border: 1px solid #dddddd;
+    margin: 20px;
+  }
+  h3 {
+    font-weight: bold;
+  }
+  .campaign h3 {
+    color: red;
+  }
+  .new-product h3 {
+    color: blue;
+  }
+  .news h3 {
+    color: green;
+  }
+{% endstyle %}
+
+
+{% comment %}
+Block: Campaign
+Featured: true
+{% endcomment %}
+{% for block in campaign_block %}
+  {% if block.settings.featured %}
+    <div class="campaign card">
+      <h3>{{ block.settings.title }}</h3>
+      <div class="text">{{ block.settings.description }}</div>
+    </div>
+  {% endif %}
+{% endfor %}
+
+{% comment %}
+Block: Campaign
+Featured: false
+{% endcomment %}
+{% for block in campaign_block %}
+  {% if block.settings.featured == false %}
+    <div class="campaign card">
+      <h3>{{ block.settings.title }}</h3>
+      <div class="text">{{ block.settings.description }}</div>
+    </div>
+  {% endif %}
+{% endfor %}
+
+{% comment %}
+Block: New Product
+Featured: true
+{% endcomment %}
+{% for block in new_product_block %}
+  {% if block.settings.featured %}
+    <div class="new-product card">
+      <h3>{{ block.settings.title }} - {{ block.settings.featured }}</h3>
+      <div class="text">{{ block.settings.description }}</div>
+    </div>
+  {% endif %}
+{% endfor %}
+
+{% comment %}
+Block: New Product
+Featured: false
+{% endcomment %}
+{% for block in new_product_block %}
+  {% if block.settings.featured == false %}
+    <div class="new-product card">
+      <h3>{{ block.settings.title }} - {{ block.settings.featured }}</h3>
+      <div class="text">{{ block.settings.description }}</div>
+    </div>
+  {% endif %}
+{% endfor %}
+
+{% comment %}
+Block: News
+Featured: true
+{% endcomment %}
+{% for block in news_block %}
+  {% if block.settings.featured %}
+    <div class="news card">
+      <h3>{{ block.settings.title }}</h3>
+      <div class="text">{{ block.settings.description }}</div>
+    </div>
+  {% endif %}
+{% endfor %}
+
+{% comment %}
+Block: News
+Featured: false
+{% endcomment %}
+{% for block in news_block %}
+  {% if block.settings.featured == false %}
+    <div class="news card">
+      <h3>{{ block.settings.title }}</h3>
+      <div class="text">{{ block.settings.description }}</div>
+    </div>
+  {% endif %}
+{% endfor %}
+
+{% schema %}
+  {
+    "name": "News Carousel",
+    "tag": "section",
+    "class": "news-carousel",
+    "blocks": [
+      {
+        "name": "Campaign",
+        "type": "campaign",
+        "settings": [
+          {
+            "id": "title",
+            "label": "Title",
+            "type": "text"
+          }, {
+            "id": "description",
+            "label": "Description",
+            "type": "textarea"
+          }, {
+            "id": "featured",
+            "label": "Featured",
+            "type": "checkbox"
+          }
+        ]
+      }, {
+        "name": "New Product",
+        "type": "new-product",
+        "settings": [
+          {
+            "id": "title",
+            "label": "Title",
+            "type": "text"
+          }, {
+            "id": "description",
+            "label": "Description",
+            "type": "textarea"
+          }, {
+            "id": "featured",
+            "label": "Featured",
+            "type": "checkbox"
+          }
+        ]
+      }, {
+        "name": "News",
+        "type": "news",
+        "settings": [
+          {
+            "id": "title",
+            "label": "Title",
+            "type": "text"
+          }, {
+            "id": "description",
+            "label": "Description",
+            "type": "textarea"
+          }, {
+            "id": "featured",
+            "label": "Featured",
+            "type": "checkbox"
+          }
+        ]
+      }
+    ]
+  }
+{% endschema %}

--- a/templates/index.liquid
+++ b/templates/index.liquid
@@ -1,10 +1,13 @@
-{% for product in collections.frontpage.products limit:4 %}
+{% for product in collections.frontpage.products limit: 4 %}
   <div>
     <a href="{{ product.url | within: collection }}">{{ product.title }}</a>
     {{ product.price | money }}
-    {% unless product.available %}<br><strong>sold out</strong>{% endunless %}
+    {% unless product.available %}<br><strong>sold out</strong>
+    {% endunless %}
     <a href="{{ product.url | within: collection }}">
       <img src="{{ product.featured_image.src | img_url: 'large' }}" alt="{{ product.featured_image.alt | escape }}">
     </a>
   </div>
 {% endfor %}
+
+{% section 'news-carousel' %}


### PR DESCRIPTION
Create a new Section named “news-carousel.liquid”, where 3 different types of blocks of information will be shown, configured with the Shopify CMS. The section has to be in the home page. There will be 3 different blocks: campaign, new-product, news. All of these blocks will have the same attributes/settings: Title (text)
Description (textarea)
Featured (checkbox)
The section has to render all the different blocks, showing the title and description. The title for the campaign has to be red, the title for the new-product has to be blue and the title for the news has to be green. Blocks who have the “Featured” attribute enabled/selected, have to appear first in the list.